### PR TITLE
working better implicit all_cul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "license": "All Rights Reserved",
       "dependencies": {
+        "@calculang/standalone": "file:../calculang/packages/standalone",
         "@codemirror/autocomplete": "^6.16.0",
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lint": "^6.7.1",
@@ -40,6 +41,19 @@
         "node": ">=18"
       }
     },
+    "../calculang/packages/standalone": {
+      "name": "@calculang/standalone",
+      "version": "0.1.0-alpha.0",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@calculang/calculang-js": "^0.1.0-alpha.8",
+        "underscore": "^1.13.7"
+      },
+      "devDependencies": {
+        "@vitest/ui": "^2.1.8",
+        "vitest": "^2.1.8"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.1.tgz",
@@ -63,6 +77,10 @@
         "css-tree": "^2.3.1",
         "is-potential-custom-element-name": "^1.0.1"
       }
+    },
+    "node_modules/@calculang/standalone": {
+      "resolved": "../calculang/packages/standalone",
+      "link": true
     },
     "node_modules/@clack/core": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:coverage": "#vitest run --coverage"
   },
   "dependencies": {
+    "@calculang/standalone": "file:../calculang/packages/standalone",
     "@codemirror/autocomplete": "^6.16.0",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lint": "^6.7.1",

--- a/src/TEMPLATE_metal_open.md
+++ b/src/TEMPLATE_metal_open.md
@@ -8,7 +8,7 @@ window.plausible = window.plausible || function() { (window.plausible.q = window
 <!--<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>-->
 
 ```js
-import { introspection as getIntrospection, compile_new, bundleIntoOne, packageCalculang_new, calls_fromDefinition } from "https://cdn.jsdelivr.net/gh/calculang/calculang@373ae56/packages/standalone/index.js" //"https://raw.githack.com/calculang/calculang/all_cul/packages/standalone/index.js"//"https://cdn.jsdelivr.net/gh/calculang/calculang@dev/packages/standalone/index.js"
+import { introspection as getIntrospection, compile_new, bundleIntoOne, packageCalculang_new, calls_fromDefinition } from "@calculang/standalone/index.js" //"https://raw.githack.com/calculang/calculang/all_cul/packages/standalone/index.js"//"https://cdn.jsdelivr.net/gh/calculang/calculang@dev/packages/standalone/index.js"
 
 
 const compiled = compilations

--- a/src/components/editor.js
+++ b/src/components/editor.js
@@ -32,8 +32,8 @@ import globals from "globals";
 
 // f9535c0 is latest all_cul commit:
 
-import { introspection as getIntrospection, compile_new, bundleIntoOne, calls_fromDefinition } from "https://cdn.jsdelivr.net/gh/calculang/calculang@373ae56/packages/standalone/index.js" //"https://raw.githack.com/calculang/calculang/all_cul/packages/standalone/index.js"//
-import {pre_fetch} from "https://cdn.jsdelivr.net/gh/calculang/calculang@373ae56/packages/standalone/pre_fetch.mjs"
+import { introspection as getIntrospection, compile_new, bundleIntoOne, calls_fromDefinition } from "@calculang/standalone/index.js" //"https://raw.githack.com/calculang/calculang/all_cul/packages/standalone/index.js"//
+import {pre_fetch} from "@calculang/standalone/pre_fetch.mjs"
 
 
 import { instance } from "@viz-js/viz";  //Playground: optimize: lose this dep >1MB
@@ -815,7 +815,7 @@ export const ab = ({entrypoint='entrypoint.cul.js', defaultFS, setModel, setIntr
 //   This specific environment doesn't offer a lot of help - but it's possible.
 // You can ask me for recipes for all of these things.
 
-import { all_cul as _orig } from '${div.entrypoint}';
+import { all_cul } from '${div.entrypoint}';
 // note: you might notice 0s being added to all_cul as you work: you can ignore them!
 
 // NEW FORMULAS HERE:

--- a/src/cul/playground.cul.js
+++ b/src/cul/playground.cul.js
@@ -3,7 +3,7 @@
 // To make the playground model reducing term assurance product types
 // see comments surrounding `claim_pp` in basicterm.cul.js
 
-import { all_cul as _orig } from './basicterm.cul.js';
+import { all_cul } from './basicterm.cul.js';
 
 // PARAMETERS FOR CONTROLS AND STRESSES
 
@@ -26,8 +26,8 @@ export const lapse_rate_factor = () => lapse_rate_factor_in ?? 1
 export const original_lapse_rates = () => original_lapse_rates_in ?? false
 
 export const lapse_rate = () => {
-  if (t() < lapse_rate_factor_delay()) return original_lapse_rates() ? Math.max(0.1 - 0.02 * duration(), 0.02) : lapse_rate_orig();
-  else return lapse_rate_factor() * (original_lapse_rates() ? Math.max(0.1 - 0.02 * duration(), 0.02) : lapse_rate_orig());
+  if (t() < lapse_rate_factor_delay()) return original_lapse_rates() ? Math.max(0.1 - 0.02 * duration(), 0.02) : lapse_rate_();
+  else return lapse_rate_factor() * (original_lapse_rates() ? Math.max(0.1 - 0.02 * duration(), 0.02) : lapse_rate_());
 }
 
 export const inflation_rate_addition = () => inflation_rate_addition_in ?? 0;
@@ -80,7 +80,7 @@ export const premium_rate_per_mille = () =>
   * net_premium_pp({ /* 1000e sum assured projection with pricing config and no stresses, and discounting always on */ sum_assured_in: 1000, original_lapse_rates_in: !update_pricing_lapse_rates(), discounting_on_in: true, sex_in: gender_neutral_pricing() ? 'F' : sex(), timing_in: 'BEF_DECR', stress_delay_in: 12 * 120, lapse_rate_factor_in: 1, mort_rate_factor_in: 1, mort_rate_Y1_add_per_mille_in: 0 });
 
 
-export const pv_pols_if = () => pv_pols_if_orig() * premium_due() // used by net_premium_pp via pv_fut_pols_if
+export const pv_pols_if = () => pv_pols_if_() * premium_due() // used by net_premium_pp via pv_fut_pols_if
 
 
 // DIFFERENT PREMIUM FREQUENCIES
@@ -111,7 +111,7 @@ export const premium_due = () => {
 // NOT annualized
 export const premium_pp = () => {
   if (!premium_due()) return 0
-  return premium_pp_orig()
+  return premium_pp_()
 }
 
 // MORTALITY RATE RECALC
@@ -140,7 +140,7 @@ export const discounting_on = () => discounting_on_in ?? true
 
 export const disc_rate_ann = () => {
   if (!discounting_on()) return 0
-  else return disc_rate_ann_orig()
+  else return disc_rate_ann_()
 }
 
 
@@ -158,7 +158,7 @@ export const status = () => duration_mth_0() == 0 ? 'New Business' : 'In Force'
 
 // spares let you add new cashflows: they are 0, but you can change them below
 // careful: manipulation in net_cf not captured in Playground outputs!
-export const net_cf = () => net_cf_orig() + placeholder() + placeholder2();
+export const net_cf = () => net_cf_() + placeholder() + placeholder2();
 
 export const placeholder = () => 0 // placeholder1 will be visualized green
 export const placeholder2 = () => 0 // placeholder2 will be visualized purpley

--- a/test/basicterm.test.js
+++ b/test/basicterm.test.js
@@ -3,7 +3,7 @@
 import { expect, describe, it } from 'vitest';
 import { resolve } from 'node:path';
 
-import { compile } from 'calculang/packages/standalone/index.js';
+import { compile } from '@calculang/standalone/index.js';
 
 import { readFile } from 'fs/promises';
 

--- a/test/playground.test.js
+++ b/test/playground.test.js
@@ -3,7 +3,7 @@
 import { expect, describe, it } from 'vitest';
 import { resolve } from 'node:path';
 
-import { compile } from 'calculang/packages/standalone/index.js';
+import { compile } from '@calculang/standalone/index.js';
 
 import { readFile } from 'fs/promises';
 


### PR DESCRIPTION
I'm testing a calculang change

To figure:

- if implicit mapped to `_orig` is better than implicit mapped to `_` (`_` namespace is already a concept in calculang)
- and if unicode greek characters will be a problem in any environments

This aims to cleanly fix a serious problem in AP: under 💬 click + button to create a new scope that imports `all_cul`, the example code manipulations provided work, but other basic calculang manipulations are setup to fail by default, basic things like:

`lapse_rate = () => 0`

or

`lapse_rate = () => lapse_rate_orig()*2`

(similar `lapse_rate_mth` manipulations do already work but that isn't the point)